### PR TITLE
:up: Update `p-map` from `5.3.0` to `6.0.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "notion-client": "^6.15.6",
     "notion-types": "^6.15.6",
     "notion-utils": "^6.15.6",
-    "p-map": "^5.3.0",
+    "p-map": "^6.0.0",
     "p-memoize": "^6.0.1",
     "patch-package": "^8.0.0",
     "posthog-js": "^1.20.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2857,6 +2857,11 @@ p-map@^5.3.0:
   dependencies:
     aggregate-error "^4.0.0"
 
+p-map@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-6.0.0.tgz#4d9c40d3171632f86c47601b709f4b4acd70fed4"
+  integrity sha512-T8BatKGY+k5rU+Q/GTYgrEf2r4xRMevAN5mtXc2aPc4rS1j3s+vWTaO2Wag94neXuCAUAs8cxBL9EeB5EA6diw==
+
 p-memoize@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/p-memoize/-/p-memoize-6.0.1.tgz"


### PR DESCRIPTION
# Description
Update `p-map` from `5.3.0` to `6.0.0`

```shell
% sudo yarn upgrade-interactive --latest   
yarn upgrade-interactive v1.22.19
info Color legend : 
 "<red>"    : Major Update backward-incompatible updates 
 "<yellow>" : Minor Update backward-compatible features 
 "<green>"  : Patch Update backward-compatible bug fixes
? Choose which packages to update. 
 dependencies
   name                                   range   from        to       url
 ◯ @keyvhq/core                           latest  2.0.0    ❯  2.1.0    https://keyv.js.org/
 ◯ @keyvhq/redis                          latest  2.0.0    ❯  2.1.0    https://github.com/microlinkhq/keyv
 ◯ @vercel/og                             latest  0.0.19   ❯  0.5.20   
 ◯ classnames                             latest  2.3.1    ❯  2.3.2    https://github.com/JedWatson/classnames#readme
 ◯ date-fns                               latest  2.28.0   ❯  2.30.0   https://github.com/date-fns/date-fns#readme
 ◯ fathom-client                          latest  3.4.1    ❯  3.5.0    https://github.com/derrickreimer/fathom-client
 ◯ got                                    latest  12.0.3   ❯  13.0.0   https://github.com/sindresorhus/got#readme
 ◯ isomorphic-unfetch                     latest  3.1.0    ❯  4.0.2    https://github.com/developit/unfetch#readme
 ◯ lqip-modern                            latest  1.2.0    ❯  2.0.0    https://github.com/transitive-bullshit/lqip-modern.git
 ◯ next                                   latest  12.3.1   ❯  13.5.6   https://nextjs.org/
 ◯ notion-client                          latest  6.15.6   ❯  6.16.0   https://github.com/NotionX/react-notion-x#readme
 ◯ notion-types                           latest  6.15.6   ❯  6.16.0   https://github.com/NotionX/react-notion-x#readme
 ◯ notion-utils                           latest  6.15.6   ❯  6.16.0   https://github.com/NotionX/react-notion-x#readme
 ◉ p-map                                  latest  5.3.0    ❯  6.0.0    https://github.com/sindresorhus/p-map#readme
❯◯ p-memoize                              latest  6.0.1    ❯  7.1.1    https://github.com/sindresorhus/p-memoize#readme
 ◯ posthog-js                             latest  1.36.1   ❯  1.84.1   https://github.com/PostHog/posthog-js#readme
 ◯ react-notion-x                         latest  6.15.6   ❯  6.16.0   https://github.com/NotionX/react-notion-x#readme
 ◯ react-use                              latest  17.3.2   ❯  17.4.0   https://github.com/streamich/react-use#readme
  
 devDependencies
   name                                   range   from        to       url
 ◯ @next/bundle-analyzer                  latest  12.3.1   ❯  13.5.6   https://github.com/vercel/next.js#readme
 ◯ @trivago/prettier-plugin-sort-imports  latest  3.3.1    ❯  4.2.0    https://github.com/trivago/prettier-plugin-sort-imports#readme
 ◯ @types/node                            latest  18.8.5   ❯  20.8.7   https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/node
 ◯ @types/react                           latest  18.0.21  ❯  18.2.31  https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react
 ◯ @typescript-eslint/eslint-plugin       latest  5.40.0   ❯  6.8.0    https://github.com/typescript-eslint/typescript-eslint#readme
 ◯ @typescript-eslint/parser              latest  5.40.0   ❯  6.8.0    https://github.com/typescript-eslint/typescript-eslint#readme
 ◯ eslint                                 latest  8.25.0   ❯  8.52.0   https://eslint.org/
 ◯ eslint-config-prettier                 latest  8.5.0    ❯  9.0.0    https://github.com/prettier/eslint-config-prettier#readme
 ◯ eslint-plugin-react                    latest  7.31.10  ❯  7.33.2   https://github.com/jsx-eslint/eslint-plugin-react
 ◯ prettier                               latest  2.7.1    ❯  3.0.3    https://prettier.io/
 ◯ typescript                             latest  4.8.4    ❯  5.2.2    https://www.typescriptlang.org/
```