### PR TITLE
:up: Update `eslint-config-prettier` from `8.5.0` to `9.0.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@typescript-eslint/parser": "^5.40.0",
     "cross-env": "^7.0.2",
     "eslint": "^8.25.0",
-    "eslint-config-prettier": "^8.5.0",
+    "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-react": "^7.31.10",
     "eslint-plugin-react-hooks": "^4.6.0",
     "npm-run-all": "^4.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1330,10 +1330,10 @@ escape-string-regexp@^4.0.0:
   resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
-eslint-config-prettier@^8.5.0:
-  version "8.5.0"
-  resolved "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz"
-  integrity sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==
+eslint-config-prettier@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-9.0.0.tgz#eb25485946dd0c66cd216a46232dc05451518d1f"
+  integrity sha512-IcJsTkJae2S35pRsRAwoCE+925rJJStOdkKnLVgtE+tEpqU0EVVM7OqrwxqgptKdX29NUwC82I5pXsGFIgSevw==
 
 eslint-plugin-react-hooks@^4.6.0:
   version "4.6.0"


### PR DESCRIPTION
#### Description
Update `eslint-config-prettier` from `8.5.0` to `9.0.0`

```shell
% sudo yarn upgrade-interactive --latest
Password:
yarn upgrade-interactive v1.22.19
info Color legend : 
 "<red>"    : Major Update backward-incompatible updates 
 "<yellow>" : Minor Update backward-compatible features 
 "<green>"  : Patch Update backward-compatible bug fixes
? Choose which packages to update. 
 dependencies
   name                                   range   from        to       url
 ◯ @keyvhq/core                           latest  2.0.0    ❯  2.1.0    https://keyv.js.org/
 ◯ @keyvhq/redis                          latest  2.0.0    ❯  2.1.0    https://github.com/microlinkhq/keyv
 ◯ @vercel/og                             latest  0.0.19   ❯  0.5.20   
 ◯ classnames                             latest  2.3.1    ❯  2.3.2    https://github.com/JedWatson/classnames#readme
 ◯ date-fns                               latest  2.28.0   ❯  2.30.0   https://github.com/date-fns/date-fns#readme
 ◯ fathom-client                          latest  3.4.1    ❯  3.5.0    https://github.com/derrickreimer/fathom-client
 ◯ got                                    latest  12.0.3   ❯  13.0.0   https://github.com/sindresorhus/got#readme
 ◯ next                                   latest  12.3.1   ❯  13.5.6   https://nextjs.org/
 ◯ notion-client                          latest  6.15.6   ❯  6.16.0   https://github.com/NotionX/react-notion-x#readme
 ◯ notion-types                           latest  6.15.6   ❯  6.16.0   https://github.com/NotionX/react-notion-x#readme
 ◯ notion-utils                           latest  6.15.6   ❯  6.16.0   https://github.com/NotionX/react-notion-x#readme
 ◯ posthog-js                             latest  1.36.1   ❯  1.84.1   https://github.com/PostHog/posthog-js#readme
 ◯ react-notion-x                         latest  6.15.6   ❯  6.16.0   https://github.com/NotionX/react-notion-x#readme
 ◯ react-use                              latest  17.3.2   ❯  17.4.0   https://github.com/streamich/react-use#readme
  
 devDependencies
   name                                   range   from        to       url
 ◯ @next/bundle-analyzer                  latest  12.3.1   ❯  13.5.6   https://github.com/vercel/next.js#readme
 ◯ @trivago/prettier-plugin-sort-imports  latest  3.3.1    ❯  4.2.0    https://github.com/trivago/prettier-plugin-sort-imports#readme
 ◯ @types/node                            latest  18.8.5   ❯  20.8.7   https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/node
 ◯ @types/react                           latest  18.0.21  ❯  18.2.31  https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react
 ◯ @typescript-eslint/eslint-plugin       latest  5.40.0   ❯  6.8.0    https://github.com/typescript-eslint/typescript-eslint#readme
 ◯ @typescript-eslint/parser              latest  5.40.0   ❯  6.8.0    https://github.com/typescript-eslint/typescript-eslint#readme
 ◯ eslint                                 latest  8.25.0   ❯  8.52.0   https://eslint.org/
❯◉ eslint-config-prettier                 latest  8.5.0    ❯  9.0.0    https://github.com/prettier/eslint-config-prettier#readme
 ◯ eslint-plugin-react                    latest  7.31.10  ❯  7.33.2   https://github.com/jsx-eslint/eslint-plugin-react
 ◯ prettier                               latest  2.7.1    ❯  3.0.3    https://prettier.io/
 ◯ typescript                             latest  4.8.4    ❯  5.2.2    https://www.typescriptlang.org/
```